### PR TITLE
Fix invalid closing tag in about page

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -161,11 +161,12 @@ const techStack = [
         />
         <li
           class="mt-8 border-t border-primary-dark-100 pt-8 dark:border-primary-dark-700/40"
+        >
           <SocialLink
             href="mailto:taylor@finklea.io"
             label="taylor@finklea.io"
             icon="mdi:email"
-          ></SocialLink>
+          />
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- correct `<li>` and `<SocialLink>` closing in `about.vue`

## Testing
- `npm run build` *(fails: Cannot find module '/workspace/portfolio/node_modules/nuxt/node_modules/unhead/dist/index.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_6881574b7ac883328b6ec5a5c17439ee