### PR TITLE
chore: upgrade vulnerable packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "TaylorFinklea",
+  "name": "taylor-finklea-portfolio",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "TaylorFinklea",
+      "name": "taylor-finklea-portfolio",
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
@@ -382,19 +382,33 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
-      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.28.2"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/parser/node_modules/@babel/types": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
@@ -1183,6 +1197,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -2011,79 +2035,215 @@
       "license": "MIT"
     },
     "node_modules/@nuxtjs/mdc": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/mdc/-/mdc-0.13.5.tgz",
-      "integrity": "sha512-bbToK+RByIKdg0bO1k5ApMn3zuBzXqRNOKGGIA4HiHTZAPpHnSHjmKRP+2qKbdth+QJ/vyBj3cHQTlMT5onxsg==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/mdc/-/mdc-0.17.3.tgz",
+      "integrity": "sha512-QAeRNDKQgf565ZhiJseEbDEZr2dY+fbxpJrDWw7kYyTmupTB+YQ++pnZKKew2ZBmRIwPzxPEhGC3JYH0vM4MVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nuxt/kit": "^3.15.2",
-        "@shikijs/transformers": "^1.27.2",
+        "@nuxt/kit": "^4.0.3",
+        "@shikijs/langs": "^3.12.1",
+        "@shikijs/themes": "^3.12.1",
+        "@shikijs/transformers": "^3.12.1",
         "@types/hast": "^3.0.4",
         "@types/mdast": "^4.0.4",
-        "@vue/compiler-core": "^3.5.13",
-        "consola": "^3.4.0",
-        "debug": "4.4.0",
+        "@vue/compiler-core": "^3.5.20",
+        "consola": "^3.4.2",
+        "debug": "^4.4.1",
         "defu": "^6.1.4",
-        "destr": "^2.0.3",
+        "destr": "^2.0.5",
         "detab": "^3.0.2",
         "github-slugger": "^2.0.0",
         "hast-util-format": "^1.1.0",
-        "hast-util-to-mdast": "^10.1.1",
+        "hast-util-to-mdast": "^10.1.2",
         "hast-util-to-string": "^3.0.1",
         "mdast-util-to-hast": "^13.2.0",
         "micromark-util-sanitize-uri": "^2.0.1",
-        "ohash": "^1.1.4",
-        "parse5": "^7.2.1",
-        "pathe": "^2.0.2",
-        "property-information": "^6.5.0",
+        "parse5": "^8.0.0",
+        "pathe": "^2.0.3",
+        "property-information": "^7.1.0",
         "rehype-external-links": "^3.0.0",
         "rehype-minify-whitespace": "^6.0.2",
         "rehype-raw": "^7.0.0",
-        "rehype-remark": "^10.0.0",
+        "rehype-remark": "^10.0.1",
         "rehype-slug": "^6.0.0",
         "rehype-sort-attribute-values": "^5.0.1",
         "rehype-sort-attributes": "^5.0.1",
-        "remark-emoji": "^5.0.1",
-        "remark-gfm": "^4.0.0",
-        "remark-mdc": "^3.5.2",
+        "remark-emoji": "^5.0.2",
+        "remark-gfm": "^4.0.1",
+        "remark-mdc": "v3.6.0",
         "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.1",
+        "remark-rehype": "^11.1.2",
         "remark-stringify": "^11.0.0",
         "scule": "^1.3.0",
-        "shiki": "^1.27.2",
-        "ufo": "^1.5.4",
+        "shiki": "^3.12.1",
+        "ufo": "^1.6.1",
         "unified": "^11.0.5",
         "unist-builder": "^4.0.0",
         "unist-util-visit": "^5.0.0",
-        "unwasm": "^0.3.9",
+        "unwasm": "^0.3.11",
         "vfile": "^6.0.3"
       }
     },
-    "node_modules/@nuxtjs/mdc/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+    "node_modules/@nuxtjs/mdc/node_modules/@nuxt/kit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.1.0.tgz",
+      "integrity": "sha512-QY6wgano7szNP5hLUKNeZTLdx009F2n+a8L9M4Wzk1jhubvENc81jLWHAnaJOogRpqMeEqZcjHRfqTx+J1/lfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.3"
+        "c12": "^3.2.0",
+        "consola": "^3.4.2",
+        "defu": "^6.1.4",
+        "destr": "^2.0.5",
+        "errx": "^0.1.0",
+        "exsolve": "^1.0.7",
+        "ignore": "^7.0.5",
+        "jiti": "^2.5.1",
+        "klona": "^2.0.6",
+        "mlly": "^1.8.0",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.0",
+        "rc9": "^2.1.2",
+        "scule": "^1.3.0",
+        "semver": "^7.7.2",
+        "std-env": "^3.9.0",
+        "tinyglobby": "^0.2.14",
+        "ufo": "^1.6.1",
+        "unctx": "^2.4.1",
+        "unimport": "^5.2.0",
+        "untyped": "^2.0.0"
       },
       "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "node": ">=18.12.0"
       }
     },
-    "node_modules/@nuxtjs/mdc/node_modules/ohash": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
-      "integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
+    "node_modules/@nuxtjs/mdc/node_modules/@shikijs/core": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.12.1.tgz",
+      "integrity": "sha512-j9+UDQ6M50xvaSR/e9lg212H0Fqxy3lYd39Q6YITYQxfrb5VYNUKPLZp4PN9f+YmRcdpyNAm3obn/tIZ2WkUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.12.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@nuxtjs/mdc/node_modules/@shikijs/engine-javascript": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.12.1.tgz",
+      "integrity": "sha512-mwif5T3rEBSMn/1m9dNi4WmB4dxH4VfYqreQMLpbFYov8MM3Gus98I549amFMjtEmYDAkTKGP7bmsv1n9t9I+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.12.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.3"
+      }
+    },
+    "node_modules/@nuxtjs/mdc/node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.12.1.tgz",
+      "integrity": "sha512-hbYq+XOc55CU7Irkhsgwh8WgQbx2W5IVzHV4l+wZ874olMLSNg5o3F73vo9m4SAhimFyqq/86xnx9h+T30HhhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.12.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@nuxtjs/mdc/node_modules/@shikijs/langs": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.12.1.tgz",
+      "integrity": "sha512-Y1MbMfVO5baRz7Boo7EoD36TmzfUx/I5n8e+wZumx6SlUA81Zj1ZwNJL871iIuSHrdsheV4AxJtHQ9mlooklmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.12.1"
+      }
+    },
+    "node_modules/@nuxtjs/mdc/node_modules/@shikijs/themes": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.12.1.tgz",
+      "integrity": "sha512-9JrAm9cA5hqM/YXymA3oAAZdnCgQf1zyrNDtsnM105nNEoEpux4dyzdoOjc2KawEKj1iUs/WH2ota6Atp7GYkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.12.1"
+      }
+    },
+    "node_modules/@nuxtjs/mdc/node_modules/@shikijs/types": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.12.1.tgz",
+      "integrity": "sha512-Is/p+1vTss22LIsGCJTmGrxu7ZC1iBL9doJFYLaZ4aI8d0VDXb7Mn0kBzhkc7pdsRpmUbQLQ5HXwNpa3H6F8og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@nuxtjs/mdc/node_modules/@vue/compiler-core": {
+      "version": "3.5.21",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.21.tgz",
+      "integrity": "sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@vue/shared": "3.5.21",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@nuxtjs/mdc/node_modules/@vue/shared": {
+      "version": "3.5.21",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.21.tgz",
+      "integrity": "sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@nuxtjs/mdc/node_modules/oniguruma-to-es": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.3.tgz",
+      "integrity": "sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/@nuxtjs/mdc/node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/@nuxtjs/mdc/node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/@nuxtjs/mdc/node_modules/pathe": {
       "version": "2.0.3",
@@ -2091,6 +2251,54 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@nuxtjs/mdc/node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@nuxtjs/mdc/node_modules/regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
+      "integrity": "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/@nuxtjs/mdc/node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/@nuxtjs/mdc/node_modules/shiki": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.12.1.tgz",
+      "integrity": "sha512-eMlxVaXyuNQAQCaMtDKQjKv0eVm+kA6fsZtv9UqKgspP+7lWCVi7SoN+cJq1dawvIDQY7TI3SixamztotM6R6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.12.1",
+        "@shikijs/engine-javascript": "3.12.1",
+        "@shikijs/engine-oniguruma": "3.12.1",
+        "@shikijs/langs": "3.12.1",
+        "@shikijs/themes": "3.12.1",
+        "@shikijs/types": "3.12.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
     },
     "node_modules/@nuxtjs/tailwindcss": {
       "version": "6.14.0",
@@ -3331,14 +3539,38 @@
       }
     },
     "node_modules/@shikijs/transformers": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.29.2.tgz",
-      "integrity": "sha512-NHQuA+gM7zGuxGWP9/Ub4vpbwrYCrho9nQCLcCPfOe3Yc7LOYwmSuhElI688oiqIXk9dlZwDiyAG9vPBTuPJMA==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.12.1.tgz",
+      "integrity": "sha512-crGh3cSZf6mwg3K2W8i79Ja+q4tVClRHdHLnUGi5arS58+cqdzsbkrEZBDMyevf9ehmjFUWDTEwCMEyp9I3z0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "1.29.2",
-        "@shikijs/types": "1.29.2"
+        "@shikijs/core": "3.12.1",
+        "@shikijs/types": "3.12.1"
+      }
+    },
+    "node_modules/@shikijs/transformers/node_modules/@shikijs/core": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.12.1.tgz",
+      "integrity": "sha512-j9+UDQ6M50xvaSR/e9lg212H0Fqxy3lYd39Q6YITYQxfrb5VYNUKPLZp4PN9f+YmRcdpyNAm3obn/tIZ2WkUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.12.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@shikijs/transformers/node_modules/@shikijs/types": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.12.1.tgz",
+      "integrity": "sha512-Is/p+1vTss22LIsGCJTmGrxu7ZC1iBL9doJFYLaZ4aI8d0VDXb7Mn0kBzhkc7pdsRpmUbQLQ5HXwNpa3H6F8og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/@shikijs/types": {
@@ -4888,9 +5120,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5012,22 +5244,22 @@
       }
     },
     "node_modules/c12": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-3.0.4.tgz",
-      "integrity": "sha512-t5FaZTYbbCtvxuZq9xxIruYydrAGsJ+8UdP0pZzMiK2xl/gNiSOy0OxhLzHUEEb0m1QXYqfzfvyIFEmz/g9lqg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.2.0.tgz",
+      "integrity": "sha512-ixkEtbYafL56E6HiFuonMm1ZjoKtIo7TH68/uiEq4DAwv9NcUX2nJ95F8TrbMeNjqIkZpruo3ojXQJ+MGG5gcQ==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",
         "confbox": "^0.2.2",
         "defu": "^6.1.4",
-        "dotenv": "^16.5.0",
-        "exsolve": "^1.0.5",
+        "dotenv": "^17.2.1",
+        "exsolve": "^1.0.7",
         "giget": "^2.0.0",
-        "jiti": "^2.4.2",
+        "jiti": "^2.5.1",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "perfect-debounce": "^1.0.0",
-        "pkg-types": "^2.1.0",
+        "pkg-types": "^2.2.0",
         "rc9": "^2.1.2"
       },
       "peerDependencies": {
@@ -5037,6 +5269,18 @@
         "magicast": {
           "optional": true
         }
+      }
+    },
+    "node_modules/c12/node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/c12/node_modules/pathe": {
@@ -5554,12 +5798,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.2.2",
@@ -6455,6 +6693,7 @@
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
       "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -6936,9 +7175,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.5.tgz",
-      "integrity": "sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
       "license": "MIT"
     },
     "node_modules/extend": {
@@ -8321,9 +8560,9 @@
       }
     },
     "node_modules/ipx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ipx/-/ipx-2.1.0.tgz",
-      "integrity": "sha512-AVnPGXJ8L41vjd11Z4akIF2yd14636Klxul3tBySxHA6PKfCOQPxBDkCFK5zcWh0z/keR6toh1eg8qzdBVUgdA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ipx/-/ipx-2.1.1.tgz",
+      "integrity": "sha512-XuM9FEGOT+/45mfAWZ5ykwkZ/oE7vWpd1iWjRffMWlwAYIRzb/xD6wZhQ4BzmPMX6Ov5dqK0wUyD0OEN9oWT6g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8751,9 +8990,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -10448,15 +10687,15 @@
       "optional": true
     },
     "node_modules/mlly": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
-      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.14.0",
-        "pathe": "^2.0.1",
-        "pkg-types": "^1.3.0",
-        "ufo": "^1.5.4"
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
       }
     },
     "node_modules/mlly/node_modules/confbox": {
@@ -11294,6 +11533,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/oniguruma-to-es": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
@@ -11718,9 +11964,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -11748,13 +11994,13 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.1.0.tgz",
-      "integrity": "sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.1",
-        "exsolve": "^1.0.1",
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
       }
     },
@@ -13150,9 +13396,9 @@
       }
     },
     "node_modules/remark-emoji": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-5.0.1.tgz",
-      "integrity": "sha512-QCqTSvcZ65Ym+P+VyBKd4JfJfh7icMl7cIOGVmPMzWkDtdD8pQ0nQG7yxGolVIiMzSx90EZ7SwNiVpYpfTxn7w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-5.0.2.tgz",
+      "integrity": "sha512-IyIqGELcyK5AVdLFafoiNww+Eaw/F+rGrNSXoKucjo95uL267zrddgxGM83GN1wFIb68pyDuAsY3m5t2Cav1pQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13285,16 +13531,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/replace-in-file/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/replace-in-file/node_modules/glob": {
@@ -15267,24 +15503,24 @@
       }
     },
     "node_modules/unimport": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.0.1.tgz",
-      "integrity": "sha512-1YWzPj6wYhtwHE+9LxRlyqP4DiRrhGfJxdtH475im8ktyZXO3jHj/3PZ97zDdvkYoovFdi0K4SKl3a7l92v3sQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.2.0.tgz",
+      "integrity": "sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==",
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.14.1",
+        "acorn": "^8.15.0",
         "escape-string-regexp": "^5.0.0",
         "estree-walker": "^3.0.3",
         "local-pkg": "^1.1.1",
         "magic-string": "^0.30.17",
         "mlly": "^1.7.4",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "pkg-types": "^2.1.0",
+        "picomatch": "^4.0.3",
+        "pkg-types": "^2.2.0",
         "scule": "^1.3.0",
         "strip-literal": "^3.0.0",
-        "tinyglobby": "^0.2.13",
-        "unplugin": "^2.3.2",
+        "tinyglobby": "^0.2.14",
+        "unplugin": "^2.3.5",
         "unplugin-utils": "^0.2.4"
       },
       "engines": {
@@ -15444,13 +15680,14 @@
       }
     },
     "node_modules/unplugin": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.5.tgz",
-      "integrity": "sha512-RyWSb5AHmGtjjNQ6gIlA67sHOsWpsbWpwDokLwTcejVdOjEkJZh7QKu14J00gDDVSh8kGH4KYC/TNBceXFZhtw==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.10.tgz",
+      "integrity": "sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw==",
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.14.1",
-        "picomatch": "^4.0.2",
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
         "webpack-virtual-modules": "^0.6.2"
       },
       "engines": {
@@ -15650,59 +15887,26 @@
       }
     },
     "node_modules/unwasm": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/unwasm/-/unwasm-0.3.9.tgz",
-      "integrity": "sha512-LDxTx/2DkFURUd+BU1vUsF/moj0JsoTvl+2tcg2AUOiEzVturhGGx17/IMgGvKUYdZwr33EJHtChCJuhu9Ouvg==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/unwasm/-/unwasm-0.3.11.tgz",
+      "integrity": "sha512-Vhp5gb1tusSQw5of/g3Q697srYgMXvwMgXMjcG4ZNga02fDX9coxJ9fAb0Ci38hM2Hv/U1FXRPGgjP2BYqhNoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "knitwork": "^1.0.0",
-        "magic-string": "^0.30.8",
-        "mlly": "^1.6.1",
-        "pathe": "^1.1.2",
-        "pkg-types": "^1.0.3",
-        "unplugin": "^1.10.0"
-      }
-    },
-    "node_modules/unwasm/node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/unwasm/node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.1.8",
+        "knitwork": "^1.2.0",
+        "magic-string": "^0.30.17",
         "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.2.0",
+        "unplugin": "^2.3.6"
       }
     },
-    "node_modules/unwasm/node_modules/pkg-types/node_modules/pathe": {
+    "node_modules/unwasm/node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/unwasm/node_modules/unplugin": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.16.1.tgz",
-      "integrity": "sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.14.0",
-        "webpack-virtual-modules": "^0.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "flowbite": "^2.5.2"
   },
   "overrides": {
-    "@nuxtjs/mdc": "^0.13.3"
+    "@nuxtjs/mdc": "^0.17.2",
+    "brace-expansion": "^2.0.2",
+    "ipx": "^2.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- fix brace-expansion security issue by overriding to 2.0.2
- force @nuxtjs/mdc to 0.17.3 to resolve high-severity advisory
- bump optional ipx dependency to 2.1.1

## Testing
- `npm test` (fails: Missing script "test")
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_68b77a5372c88332a2e079d65a8f01ed